### PR TITLE
Использовать корректную ссылку на header в `no-aside` лейауте

### DIFF
--- a/src/includes/footer.njk
+++ b/src/includes/footer.njk
@@ -1,8 +1,0 @@
-<footer class="footer" role="contentinfo">
-    <div class="footer__inner container">
-        <span>&copy; Дока {{ build.timestamp | dateToFormat('yyyy') }}</span>
-        <a href="https://github.com/Y-Doka/11ty-test" class="footer__git">
-            {% icon "github" %} Присоединиться на GitHub
-        </a>
-    </div>
-</footer>

--- a/src/layouts/no-aside.njk
+++ b/src/layouts/no-aside.njk
@@ -14,11 +14,11 @@
     <a href="#main" class="sr-skip-link">skip to main content</a>
 
     <div class="layout" role="document">
-        {% include "header.njk" %}
+        {% include "header/header.njk" %}
           <main id="main" class="main container" tabindex="-1">
             {{ content | safe }}
           </main>
-        {% include "footer.njk" %}
+        {% include "footer/footer.njk" %}
     </div>
 
     <script type="text/javascript" src="{{ '/assets/scripts/main.js' | url }}"></script>


### PR DESCRIPTION
## Что
В консоль падала ошибка, что шаблон `header.njk` не найден. 

## Как 

* Поправил ссылку (правильная `header/header.njk`)
* удалил шаблон `footer`, потому что все лейауты используют шаблон `footer/footer.njk`