### PR TITLE
Style fixes

### DIFF
--- a/src/assets/styles/base/_layout.scss
+++ b/src/assets/styles/base/_layout.scss
@@ -60,12 +60,28 @@
 
     .main {
       position: relative;
+      left: 0;
+      padding-left: 0;
+
+      .container {
+        padding: 0 20px;
+      }
     }
   }
 
   .layout {
     &__header {
-      display: none;
+      padding-top: 37px;
+      padding-left: 30px;
+
+      .header {
+        padding: 0;
+      }
+
+      .logo {
+        display: inline-block;
+        height: 30px;
+      }
     }
 
     &__footer {

--- a/src/assets/styles/base/_mainpage.scss
+++ b/src/assets/styles/base/_mainpage.scss
@@ -32,7 +32,7 @@
 
   &__logo {
     position: absolute;
-    top: 34px;
+    top: 37px;
     left: 30px;
     height: 30px;
 
@@ -186,7 +186,7 @@
     font-weight: bold;
   }
 
-  &__man {
+  &__mascot {
     width: 268px;
     height: 334px;
     background-image: url(/assets/images/logo-new.png);

--- a/src/assets/styles/base/_navpage.scss
+++ b/src/assets/styles/base/_navpage.scss
@@ -1,0 +1,67 @@
+.navpage {
+  &__header {
+    .header {
+      padding: 37px 0 0 30px;
+    }
+
+    .logo {
+      height: 30px;
+    }
+  }
+
+  .main {
+    .container {
+      width: 100%;
+      margin-left: auto;
+      margin-right: auto;
+      padding: 0 20px;
+      max-width: 1200px;
+      transition: all 0.2s ease-in;
+    }
+  }
+
+  &__block {
+    display: flex;
+    justify-content: flex-start;
+
+    @media screen and (max-width: 425px) {
+      flex-direction: column;
+    }
+  }
+
+  &__column {
+    width: calc(33% - 2em);
+    margin-right: 2em;
+
+    @media screen and (max-width: 425px) {
+      width: 100%;
+      margin-right: 0;
+    }
+  }
+
+  &__footer {
+    padding: 20px 23px 15px 37px;
+
+    .footer {
+      color: black;
+      font-size: 12px;
+    }
+  }
+
+  &__mascot {
+    width: 268px;
+    height: 334px;
+    background-image: url(/assets/images/logo-new.png);
+    background-image: url(/assets/images/logo-new.svg);
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+    position: fixed;
+    bottom: -50px;
+    right: 72px;
+
+    @media screen and (max-width: 1300px) {
+      display: none;
+    }
+  }
+}

--- a/src/assets/styles/components/_aside.scss
+++ b/src/assets/styles/components/_aside.scss
@@ -46,12 +46,12 @@
     bottom: 0;
     left: 0;
     padding: 20px 23px 15px 37px;
-    background: $nb-grey-background;
 
     &_shadow {
       -webkit-box-shadow: 0px -4px 4px 0px rgba(183, 183, 183, 0.25);
       -moz-box-shadow: 0px -4px 4px 0px rgba(183, 183, 183, 0.25);
       box-shadow: 0px -4px 4px 0px rgba(183, 183, 183, 0.25);
+      background: $nb-grey-background;
     }
   }
 

--- a/src/assets/styles/components/_header.scss
+++ b/src/assets/styles/components/_header.scss
@@ -1,5 +1,6 @@
 .header {
   padding: $spacing-y 0;
+  position: relative;
 
   &__inner {
     display: flex;

--- a/src/assets/styles/components/_vendor.scss
+++ b/src/assets/styles/components/_vendor.scss
@@ -1,0 +1,5 @@
+// Отступы для встроенного Codepen
+
+.cp_embed_wrapper {
+  margin: 1em 0 2em;
+}

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -42,3 +42,4 @@
 @import "components/search";
 @import "components/user-pic";
 @import "components/feedback-form";
+@import "components/vendor";

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -27,6 +27,7 @@
 @import "base/screenreader";
 @import "base/animation";
 @import "base/mainpage";
+@import "base/navpage";
 
 //--------------------
 // COMPONENTS

--- a/src/includes/footer/footer-no-aside.njk
+++ b/src/includes/footer/footer-no-aside.njk
@@ -1,0 +1,7 @@
+<footer class="footer">
+  <div class="footer__inner">
+    <div class="footer__support">
+      Присоединись к нам <a href="https://github.com/Y-Doka/y-doka.site" target="_blank" rel="noopener noreferrer" class="mainpage__support-link">на GitHub</a>
+    </div>
+  </div>
+</footer>

--- a/src/includes/footer/mainpage-footer.njk
+++ b/src/includes/footer/mainpage-footer.njk
@@ -2,5 +2,5 @@
   <p class="mainpage__support">
     Присоединись к нам <a href="https://github.com/Y-Doka/y-doka.site" target="_blank" rel="noopener noreferrer" class="mainpage__support-link">на GitHub</a>
   </p>
-  <div class="mainpage__man mainpage__man_sleep"></div>
+  <div class="mainpage__mascot"></div>
 </footer>

--- a/src/includes/header/header.njk
+++ b/src/includes/header/header.njk
@@ -1,9 +1,9 @@
-<header class="mainpage__header">
-  <div class="mainpage__logo">
+<header class="header">
+  <a href="/" class="header__logo">
     {% include "../ui/logo.njk" %}
-  </div>
-  <div class="mainpage__slogan">
-    <div class="mainpage__user">
+  </a>
+  <div class="header__slogan">
+    <div class="header__user">
     </div>
   </div>
 </header>

--- a/src/includes/header/mainpage-header.njk
+++ b/src/includes/header/mainpage-header.njk
@@ -1,0 +1,9 @@
+<header class="mainpage__header">
+  <div class="mainpage__logo">
+    {% include "../ui/logo.njk" %}
+  </div>
+  <div class="mainpage__slogan">
+    <div class="mainpage__user">
+    </div>
+  </div>
+</header>

--- a/src/layouts/main.njk
+++ b/src/layouts/main.njk
@@ -11,7 +11,7 @@
     {% include "meta.njk" %}
 </head>
 <body class="mainpage">
-  {% include "header/header.njk" %}
+  {% include "header/mainpage-header.njk" %}
   {{ content | safe }}
   {% include "footer/mainpage-footer.njk" %}
   <script type="text/javascript" src="{{ 'assets/scripts/main.js' | url }}"></script>

--- a/src/layouts/nav-page.njk
+++ b/src/layouts/nav-page.njk
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="{{ meta.lang }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ meta.title }}</title>
+
+    <link rel="stylesheet" href="{{ '/assets/styles/main.css' | url }}">
+    <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet">
+    {% include "meta.njk" %}
+</head>
+<body>
+    <div hidden>{% iconsprite %}</div>
+    <a href="#main" class="sr-skip-link">skip to main content</a>
+
+    <div class="navpage" role="document">
+      <div class="navpage__header">
+        {% include "header/header.njk" %}
+      </div>
+      <main id="main" class="main" tabindex="-1">
+        {{ content | safe }}
+      </main>
+      <div class="navpage__footer">
+        {% include "footer/footer-no-aside.njk" %}
+        <div class="navpage__mascot"></div>
+      </div>
+    </div>
+
+    <script type="text/javascript" src="{{ '/assets/scripts/main.js' | url }}"></script>
+</body>
+</html>

--- a/src/pages/nav-pages/css.njk
+++ b/src/pages/nav-pages/css.njk
@@ -1,29 +1,29 @@
 ---
-layout: no-aside
+layout: nav-page
 permalink: /posts/css/
 eleventyNavigation:
   key: CSS
 ---
 
 <div class="container">
-  <div style="display:flex;justify-content:space-between;">
-    <h2>CSS</h2>
-    <div style="max-width:30%">
-      <h3>Справочник</h3>
-      <ul>
+  <h2 class="navpage__title">CSS</h2>
+  <div class="navpage__block">
+    <div class="navpage__column">
+      <h3 class="navpage__subtitle">Справочник</h3>
+      <ul class="navpage__list">
         {%- for cssDoka in collections.cssDoka -%}
         <a href="/posts/{{ cssDoka.data.section }}/{{ cssDoka.data.type }}/{{ cssDoka.data.name }}">
-          <li>{{ cssDoka.data.title }}</li>
+          <li class="navpage__list-item">{{ cssDoka.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>
     </div>
-    <div style="max-width:30%">
-      <h3>Лонгриды</h3>
-      <ul>
+    <div class="navpage__column">
+      <h3 class="navpage__subtitle">Лонгриды</h3>
+      <ul class="navpage__list">
         {%- for cssLong in collections.cssLong -%}
         <a href="/posts/{{ cssLong.data.section }}/{{ cssLong.data.type }}/{{ cssLong.data.name }}">
-          <li>{{ cssLong.data.title }}</li>
+          <li class="navpage__list-item">{{ cssLong.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>

--- a/src/pages/nav-pages/cssDoka.njk
+++ b/src/pages/nav-pages/cssDoka.njk
@@ -1,19 +1,19 @@
 ---
-layout: no-aside
+layout: nav-page
 permalink: /posts/css/doka/
 eleventyNavigation:
   key: cssDoka
 ---
 
 <div class="container">
-  <div style="display:flex;justify-content:space-between;">
-    <div style="max-width:30%">
-      <h2>CSS</h2>
-      <h3>Справочник</h3>
-      <ul>
+  <h2 class="navpage__title">CSS</h2>
+  <h3 class="navpage__subtitle">Справочник</h3>
+  <div class="navpage__block">
+    <div class="navpage__column">
+      <ul class="navpage__list">
         {%- for cssDoka in collections.cssDoka -%}
         <a href="/posts/{{ cssDoka.data.section }}/{{ cssDoka.data.type }}/{{ cssDoka.data.name }}">
-          <li>{{ cssDoka.data.title }}</li>
+          <li class="navpage__list-item">{{ cssDoka.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>

--- a/src/pages/nav-pages/cssLong.njk
+++ b/src/pages/nav-pages/cssLong.njk
@@ -1,19 +1,19 @@
 ---
-layout: no-aside
+layout: nav-page
 permalink: /posts/css/long/
 eleventyNavigation:
   key: cssLong
 ---
 
 <div class="container">
-  <div style="display:flex;justify-content:space-between;">
-    <div style="max-width:30%">
-      <h2>CSS</h2>
-      <h3>Лонгриды</h3>
-      <ul>
+  <h2 class="navpage__title">CSS</h2>
+  <h3 class="navpage__subtitle">Лонгриды</h3>
+  <div class="navpage__block">
+    <div class="navpage__column">
+      <ul class="navpage__list">
         {%- for cssLong in collections.cssLong -%}
         <a href="/posts/{{ cssLong.data.section }}/{{ cssLong.data.type }}/{{ cssLong.data.name }}">
-          <li>{{ cssLong.data.title }}</li>
+          <li class="navpage__list-item">{{ cssLong.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>

--- a/src/pages/nav-pages/html.njk
+++ b/src/pages/nav-pages/html.njk
@@ -1,29 +1,29 @@
 ---
-layout: no-aside
+layout: nav-page
 permalink: /posts/html/
 eleventyNavigation:
   key: HTML
 ---
 
 <div class="container">
-  <div style="display:flex;justify-content:space-between;">
-    <h2>HTML</h2>
-    <div style="max-width:30%">      
-      <h3>Справочник</h3>
-      <ul>
+  <h2 class="navpage__title">HTML</h2>
+  <div class="navpage__block">
+    <div class="navpage__column">
+      <h3 class="navpage__subtitle">Справочник</h3>
+      <ul class="navpage__list">
         {%- for htmlDoka in collections.htmlDoka -%}
         <a href="/posts/{{ htmlDoka.data.section }}/{{ htmlDoka.data.type }}/{{ htmlDoka.data.name }}">
-          <li>{{ htmlDoka.data.title }}</li>
+          <li class="navpage__list-item">{{ htmlDoka.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>
     </div>
-    <div style="max-width:30%">
-      <h3>Лонгриды</h3>
-      <ul>
+    <div class="navpage__column">
+      <h3 class="navpage__subtitle">Лонгриды</h3>
+      <ul class="navpage__list">
         {%- for htmlLong in collections.htmlLong -%}
         <a href="/posts/{{ htmlLong.data.section }}/{{ htmlLong.data.type }}/{{ htmlLong.data.name }}">
-          <li>{{ htmlLong.data.title }}</li>
+          <li class="navpage__list-item">{{ htmlLong.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>

--- a/src/pages/nav-pages/htmlDoka.njk
+++ b/src/pages/nav-pages/htmlDoka.njk
@@ -1,19 +1,19 @@
 ---
-layout: no-aside
+layout: nav-page
 permalink: /posts/html/doka/
 eleventyNavigation:
   key: htmlDoka
 ---
 
 <div class="container">
-  <div style="display:flex;justify-content:space-between;">
-    <div style="max-width:30%">
-      <h2>HTML</h2>
-      <h3>Справочник</h3>
-      <ul>
+  <h2 class="navpage__title">HTML</h2>
+  <h3 class="navpage__subtitle">Справочник</h3>
+  <div class="navpage__block">
+    <div class="navpage__column">
+      <ul class="navpage__list">
         {%- for htmlDoka in collections.htmlDoka -%}
         <a href="/posts/{{ htmlDoka.data.section }}/{{ htmlDoka.data.type }}/{{ htmlDoka.data.name }}">
-          <li>{{ htmlDoka.data.title }}</li>
+          <li class="navpage__list-item">{{ htmlDoka.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>

--- a/src/pages/nav-pages/htmlLong.njk
+++ b/src/pages/nav-pages/htmlLong.njk
@@ -1,19 +1,19 @@
 ---
-layout: no-aside
+layout: nav-page
 permalink: /posts/html/long/
 eleventyNavigation:
   key: htmlLong
 ---
 
 <div class="container">
-  <div style="display:flex;justify-content:space-between;">
-    <div style="max-width:30%">
-      <h2>HTML</h2>
-      <h3>Лонгриды</h3>
-      <ul>
+  <h2 class="navpage__title">HTML</h2>
+  <h3 class="navpage__subtitle">Лонгриды</h3>
+  <div class="navpage__block">
+    <div class="navpage__column">
+      <ul class="navpage__list">
         {%- for htmlLong in collections.htmlLong -%}
         <a href="/posts/{{ htmlLong.data.section }}/{{ htmlLong.data.type }}/{{ htmlLong.data.name }}">
-          <li>{{ htmlLong.data.title }}</li>
+          <li class="navpage__list-item">{{ htmlLong.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>

--- a/src/pages/nav-pages/js.njk
+++ b/src/pages/nav-pages/js.njk
@@ -1,29 +1,29 @@
 ---
-layout: no-aside
+layout: nav-page
 permalink: /posts/js/
 eleventyNavigation:
   key: JavaScript
 ---
 
 <div class="container">
-  <div style="display:flex;justify-content:space-between;">
-    <h2>JavaScript</h2>
-    <div style="max-width:30%">     
-      <h3>Справочник</h3>
-      <ul>
+  <h2 class="navpage__title">JavaScript</h2>
+  <div class="navpage__block">
+    <div class="navpage__column">
+      <h3 class="navpage__subtitle">Справочник</h3>
+      <ul class="navpage__list">
         {%- for jsDoka in collections.jsDoka -%}
         <a href="/posts/{{ jsDoka.data.section }}/{{ jsDoka.data.type }}/{{ jsDoka.data.name }}">
-          <li>{{ jsDoka.data.title }}</li>
+          <li class="navpage__list-item">{{ jsDoka.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>
     </div>
-    <div style="max-width:30%">
-      <h3>Лонгриды</h3>
-      <ul>
+    <div class="navpage__column">
+      <h3 class="navpage__subtitle">Лонгриды</h3>
+      <ul class="navpage__list">
         {%- for jsLong in collections.jsLong -%}
         <a href="/posts/{{ jsLong.data.section }}/{{ jsLong.data.type }}/{{ jsLong.data.name }}">
-          <li>{{ jsLong.data.title }}</li>
+          <li class="navpage__list-item">{{ jsLong.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>

--- a/src/pages/nav-pages/jsDoka.njk
+++ b/src/pages/nav-pages/jsDoka.njk
@@ -1,19 +1,19 @@
 ---
-layout: no-aside
+layout: nav-page
 permalink: /posts/js/doka/
 eleventyNavigation:
   key: jsDoka
 ---
 
 <div class="container">
-  <div style="display:flex;justify-content:space-between;">
-    <div style="max-width:30%">
-      <h2>JavaScript</h2>
-      <h3>Справочник</h3>
-      <ul>
+  <h2 class="navpage__title">JavaScript</h2>
+  <h3 class="navpage__subtitle">Справочник</h3>
+  <div class="navpage__block">
+    <div class="navpage__column">
+      <ul class="navpage__list">
         {%- for jsDoka in collections.jsDoka -%}
         <a href="/posts/{{ jsDoka.data.section }}/{{ jsDoka.data.type }}/{{ jsDoka.data.name }}">
-          <li>{{ jsDoka.data.title }}</li>
+          <li class="navpage__list-item">{{ jsDoka.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>

--- a/src/pages/nav-pages/jsLong.njk
+++ b/src/pages/nav-pages/jsLong.njk
@@ -1,19 +1,19 @@
 ---
-layout: no-aside
+layout: nav-page
 permalink: /posts/js/long/
 eleventyNavigation:
   key: jsLong
 ---
 
 <div class="container">
-  <div style="display:flex;justify-content:space-between;">
-    <div style="max-width:30%">
-      <h2>JavaScript</h2>
-      <h3>Лонгриды</h3>
-      <ul>
+  <h2 class="navpage__title">JavaScript</h2>
+  <h3 class="navpage__subtitle">Лонгриды</h3>
+  <div class="navpage__block">
+    <div class="navpage__column">
+      <ul class="navpage__list">
         {%- for jsLong in collections.jsLong -%}
         <a href="/posts/{{ jsLong.data.section }}/{{ jsLong.data.type }}/{{ jsLong.data.name }}">
-          <li>{{ jsLong.data.title }}</li>
+          <li class="navpage__list-item">{{ jsLong.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>

--- a/src/pages/nav-pages/posts.njk
+++ b/src/pages/nav-pages/posts.njk
@@ -1,65 +1,65 @@
 ---
-layout: no-aside
+layout: nav-page
 permalink: /posts/
 eleventyNavigation:
   key: Posts
 ---
 
 <div class="container">
-  <div style="display:flex;justify-content:space-between;">
-    <div style="max-width:30%">
-      <h2>HTML</h2>
-      <h3>Справочник</h3>
-      <ul>
+  <div class="navpage__block">
+    <div class="navpage__column">
+      <h2 class="navpage__title">HTML</h2>
+      <h3 class="navpage__subtitle">Справочник</h3>
+      <ul class="navpage__list">
         {%- for htmlDoka in collections.htmlDoka -%}
         <a href="/posts/{{ htmlDoka.data.section }}/{{ htmlDoka.data.type }}/{{ htmlDoka.data.name }}">
-          <li>{{ htmlDoka.data.title }}</li>
+          <li class="navpage__list-item">{{ htmlDoka.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>
-      <h3>Лонгриды</h3>
-      <ul>
+      <h3 class="navpage__subtitle">Лонгриды</h3>
+      <ul class="navpage__list">
         {%- for htmlLong in collections.htmlLong -%}
         <a href="/posts/{{ htmlLong.data.section }}/{{ htmlLong.data.type }}/{{ htmlLong.data.name }}">
-          <li>{{ htmlLong.data.title }}</li>
+          <li class="navpage__list-item">{{ htmlLong.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>
     </div>
-    <div style="max-width:30%">
-      <h2>CSS</h2>
-      <h3>Справочник</h3>
-      <ul>
+    <div class="navpage__column">
+      <h2 class="navpage__title">CSS</h2>
+      <h3 class="navpage__subtitle">Справочник</h3>
+      <ul class="navpage__list">
         {%- for cssDoka in collections.cssDoka -%}
         <a href="/posts/{{ cssDoka.data.section }}/{{ cssDoka.data.type }}/{{ cssDoka.data.name }}">
-          <li>{{ cssDoka.data.title }}</li>
+          <li class="navpage__list-item">{{ cssDoka.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>
-      <h3>Лонгриды</h3>
-      <ul>
+      <h3 class="navpage__subtitle">Лонгриды</h3>
+      <ul class="navpage__list">
         {%- for cssLong in collections.cssLong -%}
         <a href="/posts/{{ cssLong.data.section }}/{{ cssLong.data.type }}/{{ cssLong.data.name }}">
-          <li>{{ cssLong.data.title }}</li>
+          <li class="navpage__list-item">{{ cssLong.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>
     </div>
-    <div style="max-width:30%">
-      <h2>JavaScript</h2>
+    <div class="navpage__column">
+      <h2 class="navpage__title">JavaScript</h2>
       <h3>Справочник</h3>
-      <ul>
+      <ul class="navpage__list">
         {%- for jsDoka in collections.jsDoka -%}
         <a href="/posts/{{ jsDoka.data.section }}/{{ jsDoka.data.type }}/{{ jsDoka.data.name }}">
-          <li>{{ jsDoka.data.title }}</li>
+          <li class="navpage__list-item">{{ jsDoka.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>
       <h3>Лонгриды</h3>
-      <ul>
+      <ul class="navpage__list">
         {%- for jsLong in collections.jsLong -%}
         <a href="/posts/{{ jsLong.data.section }}/{{ jsLong.data.type }}/{{ jsLong.data.name }}">
-          <li>{{ jsLong.data.title }}</li>
+          <li class="navpage__list-item">{{ jsLong.data.title }}</li>
         </a>
         {%- endfor -%}
       </ul>


### PR DESCRIPTION
- Поправлены страницы типа
    - /posts/
    - /posts/html/
    - /posts/html/doka/
- Создан отдельный layout, перенесены в отдельные подпапки
- Поправлено отображение логотипа и подвала на страницах без aside
- Поправлен фон в скрытом aside
- Поправлено расположение логотипа на главной (чтобы совпадал с остальными страницами)
- Переименован класс с маскотом на главной