### PR TITLE
added yandex.metrika counter

### DIFF
--- a/src/includes/counter/yandex-metrika-counter.njk
+++ b/src/includes/counter/yandex-metrika-counter.njk
@@ -1,0 +1,15 @@
+<!-- Yandex.Metrika counter -->
+<script type="text/javascript" >
+   (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+   m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
+   (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
+
+   ym(68516362, "init", {
+        clickmap:true,
+        trackLinks:true,
+        accurateTrackBounce:true,
+        webvisor:true
+   });
+</script>
+<noscript><div><img src="https://mc.yandex.ru/watch/68516362" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+<!-- /Yandex.Metrika counter -->

--- a/src/includes/meta.njk
+++ b/src/includes/meta.njk
@@ -27,3 +27,6 @@
 
 {# RSS Feed #}
 <link type="application/atom+xml" rel="alternate" href="{{ meta.url }}/feed.xml" title="{{ meta.title }}">
+
+{# Counters #}
+{% include "counter/yandex-metrika-counter.njk" %}


### PR DESCRIPTION
- Добавлен счётчик Яндекс.Метрики как `.njk`
- Поскольку счётчики рекомендуется располагать в `<header></header>`, подключение происходит в `meta.njk`