### PR TITLE
Добавляет владельцев репозитория

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+@furtivite @solarrust @nlopin @pepelsbey @bespoyasov
+
+src/posts/css/ @solarrust
+src/posts/html/ @solarrust
+src/posts/js/ @nlopin


### PR DESCRIPTION
Стартовая настройка владельцев репозитория.

По умолчанию кто угодно может ревьюить PR. Владельцами разделов статей сделал лидов: JS на мне, CSS + HTML на Алене. 

Возможно потом генерировать этот файл динамически и делать ревьюерами авторов тоже.

Подробнее о настройке владельцев читай в [документации гитхаба](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners).