### PR TITLE
Убирает лишние поля из package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,6 @@
 {
-  "name": "Y-DokaSite",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@11ty/dependency-tree": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,5 @@
 {
-  "name": "Y-DokaSite",
-  "version": "1.0.0",
-  "description": "The russian encyclopedia of web development",
+  "private": true,
   "scripts": {
     "sassWatch": "sass --watch src/assets/styles:dist/assets/styles",
     "sassBuild": "sass src/assets/styles/main.scss:dist/assets/styles/main.css",


### PR DESCRIPTION
В случае, когда package.json используется для хранения зависимостей проекта, который не планируется делать пакетом в npm (или где-то ещё), существует ключ `"private": true`, который это обозначает.

И уже не нужно название (оно было невалидным и подчёркивалось ошибкой), версия и описание. Я полагаю, что они там взялись из `npm init` и ни для чего не использовались. Но поправьте меня, если я неправильно всё понял.