### PR TITLE
Пробует решение с переносами

### DIFF
--- a/src/layouts/post.njk
+++ b/src/layouts/post.njk
@@ -3,7 +3,7 @@ layout: base
 ---
 <article class="article">
   <div class="article__title">
-    <h1>{{ title }}</h1>
+    <h1>{{ title | safe }}</h1>
     <a href="https://github.com/Y-Doka/y-doka.site/blob/master/{{ page.inputPath }}" class="article__title-edit" target="_blank" title="Редактировать на Github.com">&#9998;</a>
     <span class="article__section">{{ section }}</span>
   </div>

--- a/src/posts/js/doka/getelementsbyclassname.md
+++ b/src/posts/js/doka/getelementsbyclassname.md
@@ -1,5 +1,5 @@
 ---
-title: "getElementsByClassName()"
+title: "getElements&shy;ByClassName()"
 name: getelementsbyclassname
 author: N_Lopin
 co-authors:

--- a/src/posts/js/doka/getelementsbytagname.md
+++ b/src/posts/js/doka/getelementsbytagname.md
@@ -1,5 +1,5 @@
 ---
-title: "getElementsByTagName()"
+title: "getElements&shy;ByTagName()"
 name: getelementsbytagname
 author: N_Lopin
 co-authors:


### PR DESCRIPTION
Было-стало:

![image](https://user-images.githubusercontent.com/105274/102934546-650c3400-44b5-11eb-8586-44f8a1db8b41.png)

Мне кажется это можно внедрить как простое решение для сложной проблемы. Я готов дополнить пулреквест для самых тяжёлых случаев (расставить руками `&shy;` где это потребуется).

Очень сомневаюсь, что тут сработает автоматика или какое-то другое решение (шрифт придётся уменьшать до 20px, что сравнимо с размером текста).

Дополнительно, нужно будет починить поиск:

<img width="446" alt="image" src="https://user-images.githubusercontent.com/105274/102934783-e4016c80-44b5-11eb-9944-54cc1409279b.png">