### PR TITLE
Подчищает шаблон и переносит метрику

### DIFF
--- a/src/includes/meta.njk
+++ b/src/includes/meta.njk
@@ -27,6 +27,3 @@
 
 {# RSS Feed #}
 <link type="application/atom+xml" rel="alternate" href="{{ meta.url }}/feed.xml" title="{{ meta.title }}">
-
-{# Counters #}
-{% include "counter/yandex-metrika-counter.njk" %}

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -1,27 +1,29 @@
 <!DOCTYPE html>
 <html lang="{{ meta.lang }}">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ meta.title }}</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ meta.title }}</title>
 
-    <link rel="stylesheet" href="{{ '/assets/styles/main.css' | url }}">
+  <link rel="stylesheet" href="{{ '/assets/styles/main.css' | url }}">
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
 
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
-    {% include "meta.njk" %}
+  {% include "meta.njk" %}
 </head>
 <body>
-    <div hidden>{% iconsprite %}</div>
-    <a href="#main" class="sr-skip-link">skip to main content</a>
+  {% include "counter/yandex-metrika-counter.njk" %}
 
-    <div class="layout" role="document">
-      {% include "aside/aside.njk" %}
-      <main id="main" class="main container" tabindex="-1">
-        {{ content | safe }}
-      </main>
-    </div>
+  <div hidden>{% iconsprite %}</div>
+  <a href="#main" class="sr-skip-link">skip to main content</a>
 
-    <script src="{{ '/assets/scripts/main.js' | url }}"></script>
+  <div class="layout" role="document">
+    {% include "aside/aside.njk" %}
+    <main id="main" class="main container" tabindex="-1">
+      {{ content | safe }}
+    </main>
+  </div>
+
+  <script src="{{ '/assets/scripts/main.js' | url }}"></script>
 </body>
 </html>

--- a/src/layouts/main.njk
+++ b/src/layouts/main.njk
@@ -1,21 +1,29 @@
 <!DOCTYPE html>
 <html lang="{{ meta.lang }}" style="overflow-y:hidden">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="yandex-verification" content="a33683a3bd9dc8c5" />
-    <title>{{ meta.title }}</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="yandex-verification" content="a33683a3bd9dc8c5">
+  <title>{{ meta.title }}</title>
 
-    <link rel="stylesheet" href="{{ '/assets/styles/main.css' | url }}">
-    {% include "meta.njk" %}
+  <link rel="stylesheet" href="{{ '/assets/styles/main.css' | url }}">
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
+
+  {% include "meta.njk" %}
 </head>
 <body class="mainpage">
+  {% include "counter/yandex-metrika-counter.njk" %}
   {% include "header/mainpage-header.njk" %}
+
   {{ content | safe }}
+
   <img class="mainpage__mascot"
     src="/assets/images/mainpage/mascot-doka.svg"
     alt="Пёс Дока" />
+
   {% include "footer/mainpage-footer.njk" %}
+
   <script src="{{ 'assets/scripts/main.js' | url }}"></script>
 </body>
 </html>

--- a/src/layouts/nav-page.njk
+++ b/src/layouts/nav-page.njk
@@ -1,30 +1,35 @@
 <!DOCTYPE html>
 <html lang="{{ meta.lang }}">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ meta.title }}</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ meta.title }}</title>
 
-    <link rel="stylesheet" href="{{ '/assets/styles/main.css' | url }}">
-    {% include "meta.njk" %}
+  <link rel="stylesheet" href="{{ '/assets/styles/main.css' | url }}">
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
+
+  {% include "meta.njk" %}
 </head>
 <body>
-    <div hidden>{% iconsprite %}</div>
-    <a href="#main" class="sr-skip-link">skip to main content</a>
+  {% include "counter/yandex-metrika-counter.njk" %}
 
-    <div class="navpage" role="document">
-      <div class="navpage__header">
-        {% include "header/header.njk" %}
-      </div>
-      <main id="main" class="main" tabindex="-1">
-        {{ content | safe }}
-      </main>
-      <div class="navpage__footer">
-        {% include "footer/footer-no-aside.njk" %}
-        <div class="navpage__mascot"></div>
-      </div>
+  <div hidden>{% iconsprite %}</div>
+  <a href="#main" class="sr-skip-link">skip to main content</a>
+
+  <div class="navpage" role="document">
+    <div class="navpage__header">
+      {% include "header/header.njk" %}
     </div>
+    <main id="main" class="main" tabindex="-1">
+      {{ content | safe }}
+    </main>
+    <div class="navpage__footer">
+      {% include "footer/footer-no-aside.njk" %}
+      <div class="navpage__mascot"></div>
+    </div>
+  </div>
 
-    <script src="{{ '/assets/scripts/main.js' | url }}"></script>
+  <script src="{{ '/assets/scripts/main.js' | url }}"></script>
 </body>
 </html>

--- a/src/layouts/no-aside.njk
+++ b/src/layouts/no-aside.njk
@@ -1,29 +1,34 @@
 <!DOCTYPE html>
 <html lang="{{ meta.lang }}">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ meta.title }}</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ meta.title }}</title>
 
-    <link rel="stylesheet" href="{{ '/assets/styles/main.css' | url }}">
-    {% include "meta.njk" %}
+  <link rel="stylesheet" href="{{ '/assets/styles/main.css' | url }}">
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
+
+  {% include "meta.njk" %}
 </head>
 <body>
-    <div hidden>{% iconsprite %}</div>
-    <a href="#main" class="sr-skip-link">skip to main content</a>
+  {% include "counter/yandex-metrika-counter.njk" %}
 
-    <div class="layout layout_no-aside" role="document">
-      <div class="layout__header">
-        {% include "header/header.njk" %}
-      </div>
-      <main id="main" class="main" tabindex="-1">
-        {{ content | safe }}
-      </main>
-      <div class="layout__footer">
-        {% include "footer/footer.njk" %}
-      </div>
+  <div hidden>{% iconsprite %}</div>
+  <a href="#main" class="sr-skip-link">skip to main content</a>
+
+  <div class="layout layout_no-aside" role="document">
+    <div class="layout__header">
+      {% include "header/header.njk" %}
     </div>
+    <main id="main" class="main" tabindex="-1">
+      {{ content | safe }}
+    </main>
+    <div class="layout__footer">
+      {% include "footer/footer.njk" %}
+    </div>
+  </div>
 
-    <script src="{{ '/assets/scripts/main.js' | url }}"></script>
+  <script src="{{ '/assets/scripts/main.js' | url }}"></script>
 </body>
 </html>


### PR DESCRIPTION
<img width="420" alt="image" src="https://user-images.githubusercontent.com/105274/103040276-fc3fbd00-4583-11eb-9261-0027d28484e5.png">

Проверил Доку в валидаторе и нашёл, что мы вставляем неправильные теги в `<head>` вместе с Метрикой. Там в какой-то момент может оказаться `<img>`, чего быть не должно.

По пути причесал и другое:

- Переместил Метрику сразу после открываюшего `<body>`, как и должно быть (ведь так?)
- Поправил отступы с 4 на 2, по конфигу
- Подключил Гугл-шрифты на все страницы, а то они были только на одной
- Причесал форматирование шаблонов

Нам точно нужно прикрутить валидатор в тесты, он такое позволяет отлавливать и предотвращать.