### PR TITLE
Убирает CSS-вьюпорт

### DIFF
--- a/src/assets/styles/base/_reboot.scss
+++ b/src/assets/styles/base/_reboot.scss
@@ -27,42 +27,6 @@ html {
   box-sizing: inherit;
 }
 
-// Make viewport responsive
-//
-// @viewport is needed because IE 10+ doesn't honor <meta name="viewport"> in
-// some cases. See http://timkadlec.com/2012/10/ie10-snap-mode-and-responsive-design/.
-// Eventually @viewport will replace <meta name="viewport">. It's been manually
-// prefixed for forward-compatibility.
-//
-// However, `device-width` is broken on IE 10 on Windows (Phone) 8,
-// (see http://timkadlec.com/2013/01/windows-phone-8-and-device-width/ and https://github.com/twbs/bootstrap/issues/10497)
-// and the fix for that involves a snippet of JavaScript to sniff the user agent
-// and apply some conditional CSS.
-//
-// See http://getbootstrap.com/getting-started/#support-ie10-width for the relevant hack.
-//
-// Wrap `@viewport` with `@at-root` for when folks do a nested import (e.g.,
-// `.class-name { @import "bootstrap"; }`).
-//
-// Includes future-proofed vendor prefixes as well.
-@at-root {
-  @-moz-viewport {
-    width: device-width;
-  }
-  @-ms-viewport {
-    width: device-width;
-  }
-  @-o-viewport {
-    width: device-width;
-  }
-  @-webkit-viewport {
-    width: device-width;
-  }
-  @viewport {
-    width: device-width;
-  }
-}
-
 //
 // Reset HTML, body, and more
 //


### PR DESCRIPTION
Мы не поддерживаем мобильный IE10 ни в каком виде, а причины использовать этот код ссылаются на статьи 7–8-летней давности. Даже в современном [_reboot.css](https://github.com/twbs/bootstrap/blob/v4-dev/scss/_reboot.scss) нет ничего подобного.