### PR TITLE
Исправляет баг #214 с неправильным выделением элемента в сайдбаре

### DIFF
--- a/src/assets/scripts/modules/aside.js
+++ b/src/assets/scripts/modules/aside.js
@@ -13,11 +13,12 @@ function toggleAside() {
 function asideOpener() {
   let postPath = window.location.pathname.split("/").filter((el) => el)
   let [postSection, postType, postName] = postPath
+  const pageLink = `/${postSection}/${postType}/${postName}`
 
   // TODO: оптимизировать
   aside.querySelector(`.aside__${postSection}`).open = "true"
   aside.querySelector(`.aside__${postSection}-${postType}`).open = "true"
-  aside.querySelector(`[href*="${postName}"]`).classList.add("_active")
+  aside.querySelector(`[href="${pageLink}"]`).classList.add("_active")
   aside
     .querySelector(`[href*="${postName}"]._active`)
     .parentElement.scrollIntoView()


### PR DESCRIPTION
Сейчас поиск нужной ссылки в сайдбаре реализован через href*="${postName}", то есть js находит первое совпадение, которое на самом деле может только содержать postName в своём названии, но не являться нужной ссылкой.

В нашем случае text-transform стоит выше transform, но содержит transform в своём названии, поэтому при нажатии на обе эти ссылки выделяется text-transform. Лучше сделать поиск по точному совпадению ссылки.