### PR TITLE
Добавляет Elasticsearch под фича флагом

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,6 +5,7 @@ const markdownIt = require("markdown-it")
 const markdownItAnchor = require("markdown-it-anchor")
 const markdownItContainer = require("markdown-it-container")
 
+const afterBuild = require("./utils/afterBuild.js")
 const filters = require("./utils/filters.js")
 const transforms = require("./utils/transforms.js")
 const shortcodes = require("./utils/shortcodes.js")
@@ -64,7 +65,7 @@ module.exports = function (config) {
 
   // Collections
   config.addCollection("searchable", (collection) =>
-    collection.getFilteredByGlob("./src/posts/**/*.md")
+    collection.getFilteredByGlob("./src/posts/{css,js,html}/**/*.md")
   )
 
   // Sortables collections
@@ -94,6 +95,8 @@ module.exports = function (config) {
 
   // Deep-Merge
   config.setDataDeepMerge(true)
+
+  config.on("afterBuild", afterBuild.updateElasticSearch)
 
   // Base Config
   return {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,7 +5,6 @@ const markdownIt = require("markdown-it")
 const markdownItAnchor = require("markdown-it-anchor")
 const markdownItContainer = require("markdown-it-container")
 
-const afterBuild = require("./utils/afterBuild.js")
 const filters = require("./utils/filters.js")
 const transforms = require("./utils/transforms.js")
 const shortcodes = require("./utils/shortcodes.js")
@@ -95,8 +94,6 @@ module.exports = function (config) {
 
   // Deep-Merge
   config.setDataDeepMerge(true)
-
-  config.on("afterBuild", afterBuild.updateElasticSearch)
 
   // Base Config
   return {

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -19,3 +19,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run editorconfig
+      - run: npm run linthmtl

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist
 .env
 .idea
 .DS_Store
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
     command = "npm run build"
     publish = "dist"
+    functions = "serverless"
 
 [context.production.environment]
     ELEVENTY_ENV = "production"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8700,8 +8700,7 @@
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-gyp": {
       "version": "7.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1109,6 +1109,19 @@
         "kuler": "^2.0.0"
       }
     },
+    "@elastic/elasticsearch": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.10.0.tgz",
+      "integrity": "sha512-vXtMAQf5/DwqeryQgRriMtnFppJNLc/R7/R0D8E+wG5/kGM5i7mg+Hi7TM4NZEuXgtzZ2a/Nf7aR0vLyrxOK/w==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "hpagent": "^0.1.1",
+        "ms": "^2.1.1",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^2.1.0"
+      }
+    },
     "@hapi/hoek": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
@@ -6001,6 +6014,12 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+    },
+    "hpagent": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.1.tgz",
+      "integrity": "sha512-IxJWQiY0vmEjetHdoE9HZjD4Cx+mYTr25tR7JCxXaiI3QxW0YqYyM11KyZbHufoa/piWhMb2+D3FGpMgmA2cFQ==",
+      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -11260,6 +11279,12 @@
           }
         }
       }
+    },
+    "secure-json-parse": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.1.0.tgz",
+      "integrity": "sha512-GckO+MS/wT4UogDyoI/H/S1L0MCcKS1XX/vp48wfmU7Nw4woBmb8mIpu4zPBQjKlRT88/bt9xdoV4111jPpNJA==",
+      "dev": true
     },
     "select": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "luxon": "^1.25.0",
     "markdown-it": "^12.0.2",
     "memfs": "^3.1.2",
+    "node-fetch": "^2.6.1",
     "node-sass": "^5.0.0",
     "outdent": "^0.7.1",
     "sass": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@11ty/eleventy-navigation": "^0.1.6",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.4",
+    "@elastic/elasticsearch": "^7.10.0",
     "autoprefixer": "^10.1.0",
     "cross-env": "^7.0.3",
     "editorconfig-checker": "^3.3.0",

--- a/serverless/deploy-succeeded-background.js
+++ b/serverless/deploy-succeeded-background.js
@@ -11,7 +11,7 @@ const updateElasticSearch = () => {
     .bulk({
       datasource: JSON.parse(file),
       onDocument: (doc) => ({
-        index: { _index: "articles" },
+        index: { _index: "content" },
       }),
       refreshOnCompletion: true,
     })
@@ -21,6 +21,11 @@ const updateElasticSearch = () => {
 exports.handler = async function (event, context) {
   const { payload, site } = JSON.parse(event.body)
 
-  console.log("payload", payload)
-  console.log("site", site)
+  console.log("env var", process.env.CONTEXT)
+  console.log("env", process.env)
+  if (payload) {
+    const { context } = payload
+    if (context === "production") {
+    }
+  }
 }

--- a/serverless/deploy-succeeded-background.js
+++ b/serverless/deploy-succeeded-background.js
@@ -19,6 +19,8 @@ const updateElasticSearch = () => {
 }
 
 exports.handler = async function (event, context) {
-  console.log(event)
-  console.log(context)
+  const { payload, site } = JSON.parse(event.body)
+
+  console.log("payload", payload)
+  console.log("site", site)
 }

--- a/serverless/deploy-succeeded-background.js
+++ b/serverless/deploy-succeeded-background.js
@@ -18,8 +18,7 @@ const updateElasticSearch = () => {
     .then((res) => console.log(res))
 }
 
-module.exports = {
-  updateElasticSearch,
+exports.handler = async function (event, context) {
+  console.log(event.body.payload)
+  console.log(context)
 }
-
-updateElasticSearch()

--- a/serverless/deploy-succeeded-background.js
+++ b/serverless/deploy-succeeded-background.js
@@ -1,31 +1,65 @@
-const fs = require("fs")
-const path = require("path")
 const { Client } = require("@elastic/elasticsearch")
+const fetch = require("node-fetch")
 
-const updateElasticSearch = () => {
-  const elastic = new Client({ node: "http://localhost:9200" })
-  const file = fs.readFileSync(
-    path.join(__dirname, "../dist/elasticsearch-data.json")
-  )
-  elastic.helpers
-    .bulk({
-      datasource: JSON.parse(file),
-      onDocument: (doc) => ({
-        index: { _index: "content" },
-      }),
-      refreshOnCompletion: true,
+const updateElasticIndex = async (url, apiKey) => {
+  const elastic = new Client({
+    auth: { apiKey },
+    node: url,
+  })
+  const contentAlias = "content"
+  const rolloverConditions = {
+    conditions: {
+      max_age: "30d",
+    },
+  }
+
+  try {
+    await elastic.indices.rollover({
+      alias: contentAlias,
+      body: rolloverConditions,
     })
-    .then((res) => console.log(res))
+    const response = await fetch("https://y-doka.site/elasticsearch-data.json")
+    if (response.ok) {
+      const data = await response.json()
+
+      const res = await elastic.helpers.bulk({
+        datasource: data,
+        onDocument: (doc) => ({
+          index: { _index: "content", _id: doc.id },
+        }),
+        refreshOnCompletion: true,
+      })
+      console.log(res)
+    } else {
+      console.error(
+        `Cannot get documents to add. Response status ${res.status}`
+      )
+    }
+  } catch (e) {
+    console.log(e.meta.body.error)
+    console.log(e.meta.meta.request)
+  }
 }
 
-exports.handler = async function (event, context) {
-  const { payload, site } = JSON.parse(event.body)
+exports.handler = async function (event) {
+  const { payload } = JSON.parse(event.body)
 
-  console.log("env var", process.env.CONTEXT)
-  console.log("env", process.env)
   if (payload) {
     const { context } = payload
+    const { ELASTIC_WRITE_KEY: apiKey, ELASTIC_URL: elasticUrl } = process.env
     if (context === "production") {
+      if (!elasticUrl || !apiKey) {
+        console.error(
+          "Environment variables for ElasticSearch are not set. Both ELASTIC_URL and ELASTIC_WRITE_KEY must be set"
+        )
+        return
+      }
+
+      await updateElasticIndex(elasticUrl, apiKey)
+    } else {
+      console.log(
+        "Skip update of search data. The search data is updated only for production builds"
+      )
     }
   }
 }

--- a/serverless/deploy-succeeded-background.js
+++ b/serverless/deploy-succeeded-background.js
@@ -19,6 +19,6 @@ const updateElasticSearch = () => {
 }
 
 exports.handler = async function (event, context) {
-  console.log(event.body.payload)
+  console.log(event)
   console.log(context)
 }

--- a/src/elasticsearch-data.njk
+++ b/src/elasticsearch-data.njk
@@ -12,12 +12,11 @@ permalink: elasticsearch-data.json
     {% set defaultURL = item.url %}
   {% endif %}
   {
-  "title": "{{ item.data.title | lower | safe }}",
+  "title": "{{ item.data.title | safe }}",
+  "name": "{{ item.data.name | safe }}",
   "summary" : "{{ item.data.summary | default( [], true) | join(" ") | safe }}",
-  "type" : "{{ item.type | lower }}",
   "url": "{{defaultURL}}",
   "tags" : "{{ item.data.tags | safe }}",
   "text": {{item.templateContent | striptags | jsonStringify | safe }}
-  }
-  {% if not loop.last %},{% endif %}
+  }{% if not loop.last %},{% endif %}
 {%- endfor %}]

--- a/src/elasticsearch-data.njk
+++ b/src/elasticsearch-data.njk
@@ -1,0 +1,23 @@
+---
+permalink: elasticsearch-data.json
+---
+
+[{%- for item in collections.searchable %}
+  {% set defaultURL = '' %}
+  {% if item.data.links[0] %}
+    {% for name, link in item.data.links[0] %}
+      {% set defaultURL = link %}
+    {% endfor %}
+  {% else %}
+    {% set defaultURL = item.url %}
+  {% endif %}
+  {
+  "title": "{{ item.data.title | lower | safe }}",
+  "summary" : "{{ item.data.summary | default( [], true) | join(" ") | safe }}",
+  "type" : "{{ item.type | lower }}",
+  "url": "{{defaultURL}}",
+  "tags" : "{{ item.data.tags | safe }}",
+  "text": {{item.templateContent | striptags | jsonStringify | safe }}
+  }
+  {% if not loop.last %},{% endif %}
+{%- endfor %}]

--- a/utils/afterBuild.js
+++ b/utils/afterBuild.js
@@ -1,0 +1,25 @@
+const fs = require("fs")
+const path = require("path")
+const { Client } = require("@elastic/elasticsearch")
+
+const updateElasticSearch = () => {
+  const elastic = new Client({ node: "http://localhost:9200" })
+  const file = fs.readFileSync(
+    path.join(__dirname, "../dist/elasticsearch-data.json")
+  )
+  elastic.helpers
+    .bulk({
+      datasource: JSON.parse(file),
+      onDocument: (doc) => ({
+        index: { _index: "articles" },
+      }),
+      refreshOnCompletion: true,
+    })
+    .then((res) => console.log(res))
+}
+
+module.exports = {
+  updateElasticSearch,
+}
+
+updateElasticSearch()

--- a/utils/filters.js
+++ b/utils/filters.js
@@ -36,6 +36,10 @@ module.exports = {
     return path.replace(/^\/posts/, "")
   },
 
+  jsonStringify: function (value) {
+    return JSON.stringify(value)
+  },
+
   sortByKey: function (arr, key) {
     if (!key) {
       return arr


### PR DESCRIPTION
## Что это

Альтернативный вариант поиска по сайту через отдельный поисковый сервис, который умеет полнотекстовый поиск.

☝️ Чтобы протестировать вживую, нужно добавить параметр `elastic` к урлу сайта. Например, https://y-doka.site?elastic=1

## Зачем

Сейчас поиск на сайте ищет только по заголовку материала (`title`) и ключевым словам (`summary`). При этом ищется _полное вхождение_ поисковой фразы. Например, статью «Таблицы» можно найти по фразе «Таблиц», но не «Таблица». Хочется на такие запросы тоже находить релевантный контент.

## Как

Вынести задачу поиска в отдельный сервис. Самым популярный поисковым движок на сегодня — [ElasticSearch](elastic.co/). Он закрывает все наши потребности по полнотекстовому поиску, поддерживает русский язык из коробки, настраиваемые стоп-слова. 

Минусы для нас:
* сложность стартовой настройки
* появляется стоимость обслуживания внешнего сервиса

Чтобы поиск начал работать, нужно решить две задачи:
* помещать в эластик данные
* отправлять запрос с клиента на API эластика

### Отправка запроса с клиента

Вместо загрузки файла с индексом мы теперь отправляем запрос на внешний сервис. Стартовая реализация простая, но дальше нужно итерировать:

* подобрать оптимальный поисковый запрос (👈 вот тут пока у меня плохо)
* убирать из исходного кода ключи для API  

### Отправка данных в эластик

Эластик стандартно используют в приложениях с сервером. В этом случае запись в эластике обновляют на каждое изменение записи в базе данных. У нас нет сервера, все генерируется на этапе сборки. Нужно искать другие подходы.

Здесь опишу стратегию, на которой я остановился. Альтернативные стратегии ищите ниже в разделе «Альтернативы».

**Идея**: использовать pull-модель обновления — сначала деплой master-ветки Доки, а затем полное обновление индекса в эластике. Несколько секунд/минут новый сайт будет использовать старый индекс, но это ок. В худшем случае мы не найдем новые статьи (альтернатива — эластик уже обновился и отдает урлы статей, которых нет в текущем деплое 😬).

![Схема работы](https://user-images.githubusercontent.com/1469636/106963721-4c906a00-6741-11eb-8573-578c08c889e8.png)

Технически это реализовано через [serverless функции Netlify](https://docs.netlify.com/functions/build-with-javascript/). Функция начинает свою работу сразу по завершении деплоя, у нее есть 15 минут на выполнение работы. Функция вызывает публичное API доки с текстами статей (что-то похожее на текущий `search-data.json`) и перекладывает их в эластик. После того, как эластик прожевал статьи, они доступны для поиска.

Узкое место здесь — 15 минут на выполнение функции. Чтобы выйти за лимит, у нас должны быть сотни мегабайтов статей. Кажется это наступит не скоро.

## Альтернативные решения

### Подгружаемый на сайт поисковый движок

[Stork](https://stork-search.net/) — поисковый движок написанный на Rust, который подгружается на сайт как wasm модуль. 

Архитектурно движок работает так же, как и текущее решение. При загрузке страницы тянется wasm-модуль (450Кб) + как только пользователь начинает печатать поисковую фразу, отправляется запрос на получение данных индекса:

![Размер загруженных файлов](https://user-images.githubusercontent.com/1469636/106962222-1520be00-673f-11eb-9524-09cde2fcc7aa.png)

✚ простое решение
✚ умеет нормализовывать слова и подобные плюшки
➖ немаленький подгружаемый модуль
➖ размер индекса для скачивания будет только расти
➖ мало документации и поддержки
➖ непонятно, все ли ок с русским языком

### Использовать внешний поиск

Вставить поиск Яндекса

✚ простое решение
➖ уводим пользователя со страницы
➖ нет контроля над индексированием

###  Push модель обновления  Elasticsearch

Во время сборки master-ветки собирать статьи и отправлять их Эластик. 

✚ синхронно и просто
➖ между сборкой и деплоем может пройти произвольное количество времени. Все это время текущий деплой будет работать с новой версией индекса, которая может отдавать ссылки на новые материалы → пользователь будет видеть 404
