### PR TITLE
Правит описание и код у свойства `place-items`

### DIFF
--- a/src/posts/css/doka/place-items.md
+++ b/src/posts/css/doka/place-items.md
@@ -2,6 +2,8 @@
 title: "place-items"
 name: place-items
 author: ABatickaya
+contributors:
+  - corocoto
 summary:
   - выравнивание в гридах
   - шорткат
@@ -9,20 +11,20 @@ summary:
 
 ## Кратко
 
-Шорткат для указания значений сразу и для `align-items` и для `justify-content`. Указывать нужно именно в таком порядке.
+Шорткат для указания значений сразу и для `align-items` и для `justify-items`. Указывать нужно именно в таком порядке.
 
 ## Пример
 
 ```css
 .container {
   display: grid;
-  place-items: stretch / end;
+  place-items: stretch end;
 }
 ```
 
 ## Как пишется
 
-Пишутся два доступных значения для свойств [`align-items`](/css/doka/align-items) и [`justify-content`](/css/doka/justify-content), разделённые слэшем.
+Пишутся два доступных значения для свойств [`align-items`](/css/doka/align-items) и [`justify-items`](/css/doka/justify-items), разделённые пробелом.
 
 ## Подсказки
 

--- a/src/posts/css/long/grid-guide.md
+++ b/src/posts/css/long/grid-guide.md
@@ -605,12 +605,12 @@ CSS Grid Layout ([спецификация](https://www.w3.org/TR/css-grid-1/)) 
 
 ### `place-items`
 
-Шорткат для указания значений сразу и для `align-items` и для `justify-content`. Указывать нужно именно в таком порядке.
+Шорткат для указания значений сразу и для `align-items` и для `justify-items`. Указывать нужно именно в таком порядке.
 
 ```css
 .container {
   display: grid;
-  place-items: stretch / end;
+  place-items: stretch end;
 }
 ```
 


### PR DESCRIPTION
### Описание проблемы:

При попытке задания значений через слэш браузер начинает подсвечивать его, как невалидное:

![image](https://user-images.githubusercontent.com/37180024/115184998-a4efca80-a0e7-11eb-9ad5-91a675a9e808.png)

### Решение:

Почитав **[раздел про `place-items`](https://developer.mozilla.org/en-US/docs/Web/CSS/place-items)**, заметил, что значения задаются через пробел:

![image](https://user-images.githubusercontent.com/37180024/115185129-eb452980-a0e7-11eb-855c-b5dbc4be1f31.png)


>Также заметил, что это шортхэнд для `align-items` и `justify-items` (в Доке описано, что для`align-items` и `justify-content` ). Поэтому этот пункт тоже поправил 😌